### PR TITLE
ENH: Update default network interface

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@
 docker_swarm_port: 2377
 
 # Network interface to use
-docker_swarm_network_interface: "eth0"
+docker_swarm_network_interface: "{{ ansible_default_ipv4['interface'] }}"


### PR DESCRIPTION
Using "ansible_default_ipv4['interface']" to get network interface.

The "eth0" is common. But I think, a value of "[ansible_default_ipv4](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variables-discovered-from-systems-facts)" is more useful for common cases.
In my case, the default network interface of my machine is "enp3s0" and the "ansible_default_ipv4" get correctly.
