### PR TITLE
Update docker-compose.yml

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: "3.2"
 
 services:


### PR DESCRIPTION
Added missing`---` which causes a `yamllint` warning.