### PR TITLE
Improves the quality score on ansible galaxy.

### DIFF
--- a/tasks/labels.yml
+++ b/tasks/labels.yml
@@ -36,10 +36,12 @@
   command: >-
     docker node update --label-rm {{ item }} {{ docker_swarm_node_id }}
   delegate_to: "{{ docker_swarm_primary_manager_name }}"
-  with_items: >
-    {{ docker_swarm_current_labels |
-        list |
+  vars:
+    labels_to_add: >
+      {{ docker_swarm_current_labels | list |
         difference(docker_swarm_labels | default({}) | list) }}
+  with_items: "{{ labels_to_add }}"
+  when: (labels_to_add | length) > 0
   tags:
     - docker-swarm-labels
 


### PR DESCRIPTION
This pull-request fixes the quality warnings on the Ansible Galaxy.

```
--> Executing Ansible Lint on

    /molecule/default/playbook.yml...
    [104] Found a bare variable '{{ docker_swarm_current_labels |
        list |
        difference(docker_swarm_labels | default({}) | list) }}
    ' used in a 'with_items' loop. You should use the full variable syntax ('{{{{ docker_swarm_current_labels |
        list |
        difference(docker_swarm_labels | default({}) | list) }}
    }}')
    /tasks/labels.yml:35
    Task/Handler: labels | Remove old labels

    [301] Commands should not change things if nothing needs doing
    /tasks/labels.yml:35
    Task/Handler: labels | Remove old labels
```

I have changed the task "labels | Remove old labels". I did test the change on my local machine by running a modified molecule test to see if labels are removed. The test was successful.

I also saw, that there is actually no dedicated test for the removing of labels. I would add such test if the repository is still active. 